### PR TITLE
Feature/washing

### DIFF
--- a/src/main/java/gdg/hongik/project/gollazoom/closet/controller/ClosetController.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/controller/ClosetController.java
@@ -128,7 +128,7 @@ public class ClosetController {
             @RequestBody ClothWashStatusUpdateRequest request
     ) {
         closetService.updateWashStatus(userId, clothId, request);
-        return ResponseEntity.ok(ApiResponse.ok(null));
+        return ResponseEntity.ok(ApiResponse.ok("세탁 상태가 변경되었어요.", null));
     }
 
     // 일괄 변경
@@ -138,7 +138,7 @@ public class ClosetController {
             @RequestBody ClothWashStatusBulkUpdateRequest request
     ) {
         closetService.updateWashStatusBulk(userId, request);
-        return ResponseEntity.ok(ApiResponse.ok(null));
+        return ResponseEntity.ok(ApiResponse.ok("세탁 상태가 변경되었어요.", null));
     }
 
 

--- a/src/main/java/gdg/hongik/project/gollazoom/closet/controller/ClosetController.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/controller/ClosetController.java
@@ -1,14 +1,14 @@
 package gdg.hongik.project.gollazoom.closet.controller;
 
-import gdg.hongik.project.gollazoom.closet.dto.ClosetCreateRequest;
-import gdg.hongik.project.gollazoom.closet.dto.ClosetItemListResponse;
-import gdg.hongik.project.gollazoom.closet.dto.ClosetResponse;
-import gdg.hongik.project.gollazoom.closet.dto.ClosetUpdateRequest;
+import gdg.hongik.project.gollazoom.closet.dto.*;
 import gdg.hongik.project.gollazoom.closet.service.ClosetService;
+import gdg.hongik.project.gollazoom.global.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -47,18 +47,18 @@ public class ClosetController {
 
     /**
      * 옷장에 등록된 모든 옷을 조회합니다.
-     *
-     * @param auth
-     * @return
+     * @param userId : 유저 정보
+     * @param includeWashing : 세탁 중인 옷들도 포함하여 보여줄지 판단합니다.
+     * @return : 옷 리스트
      */
     @GetMapping
     @Operation(summary = "모든 옷 조회", description = "옷장에 등록된 모든 옷을 조회합니다")
     public List<ClosetItemListResponse> clothingList(
-            // required = false 위와 같은 이유.
-            Authentication auth
+            @AuthenticationPrincipal Long userId,
+            // 추천에서는 세탁중 옷 제외. 추후 흐리게 보이게 하기 등 조치 취해야 한다면 수정 가능.
+            @RequestParam(defaultValue = "false") boolean includeWashing
     ) {
-        Long userId = (Long) auth.getPrincipal();
-        return closetService.list(userId);
+        return closetService.list(userId, includeWashing);
     }
 
     /**
@@ -119,4 +119,27 @@ public class ClosetController {
         Long userId = (Long) auth.getPrincipal();
         closetService.delete(userId, clothId);
     }
+
+    // 단일 변경
+    @PatchMapping("/clothes/{clothId}/wash-status")
+    public ResponseEntity<ApiResponse<Void>> updateWashStatus(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long clothId,
+            @RequestBody ClothWashStatusUpdateRequest request
+    ) {
+        closetService.updateWashStatus(userId, clothId, request);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    // 일괄 변경
+    @PatchMapping("/clothes/wash-status")
+    public ResponseEntity<ApiResponse<Void>> updateWashStatusBulk(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody ClothWashStatusBulkUpdateRequest request
+    ) {
+        closetService.updateWashStatusBulk(userId, request);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+
 }

--- a/src/main/java/gdg/hongik/project/gollazoom/closet/dto/ClosetItemListResponse.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/dto/ClosetItemListResponse.java
@@ -2,12 +2,16 @@ package gdg.hongik.project.gollazoom.closet.dto;
 
 import gdg.hongik.project.gollazoom.closet.entity.Category;
 import gdg.hongik.project.gollazoom.closet.entity.Season;
+import gdg.hongik.project.gollazoom.closet.entity.WashStatus;
+
+import java.time.LocalDateTime;
 
 public record ClosetItemListResponse(
         Long clothId,
         String imageUrl,
         Category category,
         Season season,
-        boolean isRaining
-        // LocalDateTime lastWornAt 은 wears가 구현되고 나서 추가하겠습니다.
+        boolean isRaining,
+        WashStatus washstatus,
+        LocalDateTime lastWornAt
 ) { }

--- a/src/main/java/gdg/hongik/project/gollazoom/closet/dto/ClosetResponse.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/dto/ClosetResponse.java
@@ -13,6 +13,6 @@ public record ClosetResponse(
         String memo,
         String imageUrl,
         boolean isRaining,
-        LocalDateTime createAt
-        // LocalDateTime lastWornAt 역시 구현되면 추가하겠습니다.
+        LocalDateTime createAt,
+        LocalDateTime lastWornAt
 ) {}

--- a/src/main/java/gdg/hongik/project/gollazoom/closet/dto/ClothWashStatusBulkUpdateRequest.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/dto/ClothWashStatusBulkUpdateRequest.java
@@ -1,0 +1,12 @@
+package gdg.hongik.project.gollazoom.closet.dto;
+
+import gdg.hongik.project.gollazoom.closet.entity.WashStatus;
+
+import java.util.List;
+
+// 일괄 변경
+public record ClothWashStatusBulkUpdateRequest(
+        List<Long> clothIds,
+        WashStatus washStatus
+) {
+}

--- a/src/main/java/gdg/hongik/project/gollazoom/closet/dto/ClothWashStatusUpdateRequest.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/dto/ClothWashStatusUpdateRequest.java
@@ -1,0 +1,8 @@
+package gdg.hongik.project.gollazoom.closet.dto;
+
+import gdg.hongik.project.gollazoom.closet.entity.WashStatus;
+
+// 단일 변경
+public record ClothWashStatusUpdateRequest(
+        WashStatus washStatus
+) {}

--- a/src/main/java/gdg/hongik/project/gollazoom/closet/entity/Cloth.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/entity/Cloth.java
@@ -43,6 +43,10 @@ public class Cloth extends BaseEntity {
     @Column(nullable = false)
     private boolean isRaining;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private WashStatus washStatus = WashStatus.AVAILABLE; // 기본값
+
     public Cloth(User user, Category category, Season season, String color, String memo, String imageUrl, boolean isRaining) {
         this.user = user;
         this.category = category;
@@ -53,6 +57,7 @@ public class Cloth extends BaseEntity {
         this.isRaining = isRaining;
     }
 
+    // update 메서드에 washStatus는 넣지 않음.
     public void update(Category category, Season season, String color, String memo, String imageUrl, boolean isRaining) {
         if (category != null) this.category = category;
         if (season != null) this.season = season;

--- a/src/main/java/gdg/hongik/project/gollazoom/closet/entity/Cloth.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/entity/Cloth.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -47,6 +49,9 @@ public class Cloth extends BaseEntity {
     @Column(nullable = false, length = 20)
     private WashStatus washStatus = WashStatus.AVAILABLE; // 기본값
 
+    @Column
+    private LocalDateTime lastWornAt;
+
     public Cloth(User user, Category category, Season season, String color, String memo, String imageUrl, boolean isRaining) {
         this.user = user;
         this.category = category;
@@ -65,5 +70,13 @@ public class Cloth extends BaseEntity {
         if (memo != null) this.memo = memo;
         if (imageUrl != null) this.imageUrl = imageUrl;
         this.isRaining = isRaining;
+    }
+
+    public void changeWashStatus(WashStatus washStatus) {
+        this.washStatus = washStatus;
+    }
+
+    public void updateLastWornAt(LocalDateTime time) {
+        this.lastWornAt = time;
     }
 }

--- a/src/main/java/gdg/hongik/project/gollazoom/closet/entity/WashStatus.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/entity/WashStatus.java
@@ -1,0 +1,6 @@
+package gdg.hongik.project.gollazoom.closet.entity;
+
+public enum WashStatus {
+    AVAILABLE, // 입을 수 있는 상태
+    WASHING // 세탁 중
+}

--- a/src/main/java/gdg/hongik/project/gollazoom/closet/repository/ClothRepository.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/repository/ClothRepository.java
@@ -1,6 +1,7 @@
 package gdg.hongik.project.gollazoom.closet.repository;
 
 import gdg.hongik.project.gollazoom.closet.entity.Cloth;
+import gdg.hongik.project.gollazoom.closet.entity.WashStatus;
 import gdg.hongik.project.gollazoom.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -17,6 +18,9 @@ public interface ClothRepository extends JpaRepository<Cloth, Long> {
 
     // wears API에서 여러 옷이 전부 내 옷인지 검증한다.
     List<Cloth> findAllByIdInAndUser_Id(List<Long> clothIds, Long userId);
+
+    // 세탁중인 옷을 제외하고 가져오기
+    List<Cloth> findAllByUser_IdAndWashStatusNotOrderByCreatedAtDesc(Long userId, WashStatus washStatus);
 
     Long user(User user);
 }

--- a/src/main/java/gdg/hongik/project/gollazoom/closet/service/ClosetService.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/service/ClosetService.java
@@ -1,16 +1,15 @@
 package gdg.hongik.project.gollazoom.closet.service;
 
-import gdg.hongik.project.gollazoom.closet.dto.ClosetCreateRequest;
-import gdg.hongik.project.gollazoom.closet.dto.ClosetItemListResponse;
-import gdg.hongik.project.gollazoom.closet.dto.ClosetResponse;
-import gdg.hongik.project.gollazoom.closet.dto.ClosetUpdateRequest;
+import gdg.hongik.project.gollazoom.closet.dto.*;
 
 import java.util.List;
 
 public interface ClosetService {
     ClosetResponse create(Long userId, ClosetCreateRequest request);
-    List<ClosetItemListResponse> list(Long userId);
+    List<ClosetItemListResponse> list(Long userId, boolean includeWashing);
     ClosetResponse get(Long userId, Long clothId);
     ClosetResponse update(Long userId, Long clothId, ClosetUpdateRequest request);
     void delete(Long userId, Long clothId);
+    void updateWashStatus(Long userId, Long clothId, ClothWashStatusUpdateRequest request);
+    void updateWashStatusBulk(Long userId, ClothWashStatusBulkUpdateRequest request);
 }

--- a/src/main/java/gdg/hongik/project/gollazoom/closet/service/ClosetServiceImpl.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/closet/service/ClosetServiceImpl.java
@@ -1,11 +1,9 @@
 package gdg.hongik.project.gollazoom.closet.service;
 
-import gdg.hongik.project.gollazoom.closet.dto.ClosetCreateRequest;
-import gdg.hongik.project.gollazoom.closet.dto.ClosetItemListResponse;
-import gdg.hongik.project.gollazoom.closet.dto.ClosetResponse;
-import gdg.hongik.project.gollazoom.closet.dto.ClosetUpdateRequest;
+import gdg.hongik.project.gollazoom.closet.dto.*;
 import gdg.hongik.project.gollazoom.closet.entity.Category;
 import gdg.hongik.project.gollazoom.closet.entity.Cloth;
+import gdg.hongik.project.gollazoom.closet.entity.WashStatus;
 import gdg.hongik.project.gollazoom.closet.repository.ClothRepository;
 import gdg.hongik.project.gollazoom.user.entity.User;
 import gdg.hongik.project.gollazoom.user.repository.UserRepository;
@@ -66,9 +64,20 @@ public class ClosetServiceImpl implements ClosetService {
      */
     @Override
     @Transactional(readOnly = true)
-    public List<ClosetItemListResponse> list(Long userId) {
-        return clothRepository.findAllByUser_IdOrderByCreatedAtDesc(userId)
-                .stream()
+    public List<ClosetItemListResponse> list(Long userId, boolean includeWashing) {
+        List<Cloth> clothes;
+
+        // 세탁 중인 옷을 조회에 포함시킬 것인가?
+        if (includeWashing) {
+            clothes = clothRepository.findAllByUser_IdOrderByCreatedAtDesc(userId);
+        } else {
+            clothes = clothRepository.findAllByUser_IdAndWashStatusNotOrderByCreatedAtDesc(
+                    userId,
+                    WashStatus.WASHING
+            );
+        }
+
+        return clothes.stream()
                 .map(this::toListItem)
                 .toList();
     }
@@ -158,7 +167,8 @@ public class ClosetServiceImpl implements ClosetService {
                 cloth.getMemo(),
                 cloth.getImageUrl(),
                 cloth.isRaining(),
-                cloth.getCreatedAt()
+                cloth.getCreatedAt(),
+                cloth.getLastWornAt()
         );
     }
 
@@ -174,7 +184,42 @@ public class ClosetServiceImpl implements ClosetService {
                 cloth.getImageUrl(),
                 cloth.getCategory(),
                 cloth.getSeason(),
-                cloth.isRaining()
+                cloth.isRaining(),
+                cloth.getWashStatus(),
+                cloth.getLastWornAt()
         );
+    }
+
+    @Override
+    public void updateWashStatus(Long userId, Long clothId, ClothWashStatusUpdateRequest request) {
+        if (request == null || request.washStatus() == null) {
+            throw new IllegalArgumentException("washStatus는 필수입니다.");
+        }
+
+        Cloth cloth = clothRepository.findByIdAndUser_Id(clothId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("옷을 찾을 수 없습니다."));
+
+        cloth.changeWashStatus(request.washStatus());
+    }
+
+    @Override
+    public void updateWashStatusBulk(Long userId, ClothWashStatusBulkUpdateRequest request) {
+        if (request == null || request.washStatus() == null) {
+            throw new IllegalArgumentException("세탁 상태를 표시해주세요.");
+        }
+        if (request.clothIds() == null || request.clothIds().isEmpty()) {
+            throw new IllegalArgumentException("세탁상태를 변경할 옷을 선택해주세요.");
+        }
+
+        List<Cloth> clothes = clothRepository.findAllByIdInAndUser_Id(request.clothIds(), userId);
+
+        // 요청 개수 != 조회 개수면 남의 옷이 섞였거나 없는 id
+        if (clothes.size() != request.clothIds().size()) {
+            throw new IllegalArgumentException("요청한 clothIds 중 유효하지 않은 값이 포함되어 있습니다.");
+        }
+
+        for (Cloth c : clothes) {
+            c.changeWashStatus(request.washStatus());
+        }
     }
 }

--- a/src/main/java/gdg/hongik/project/gollazoom/global/api/ApiResponse.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/global/api/ApiResponse.java
@@ -12,4 +12,8 @@ public record ApiResponse<T>(
     public static <T> ApiResponse<T> fail(String message, T data) {
         return new ApiResponse<>(false, message, data);
     }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, null, data);
+    }
 }

--- a/src/main/java/gdg/hongik/project/gollazoom/presets/controller/PresetController.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/presets/controller/PresetController.java
@@ -1,13 +1,16 @@
 package gdg.hongik.project.gollazoom.presets.controller;
 
+import gdg.hongik.project.gollazoom.global.api.ApiResponse;
 import gdg.hongik.project.gollazoom.presets.dto.request.PresetCreateRequest;
 import gdg.hongik.project.gollazoom.presets.dto.request.PresetUpdateRequest;
 import gdg.hongik.project.gollazoom.presets.dto.response.PresetCreateResponse;
 import gdg.hongik.project.gollazoom.presets.dto.response.PresetDetailResponse;
 import gdg.hongik.project.gollazoom.presets.dto.response.PresetListResponse;
+import gdg.hongik.project.gollazoom.presets.dto.response.PresetWashCheckResponse;
 import gdg.hongik.project.gollazoom.presets.service.PresetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,6 +36,15 @@ public class PresetController {
                 .getAuthentication()
                 .getPrincipal();
         return ResponseEntity.ok(presetService.getPresetDetail(userId, presetId));
+    }
+
+    @GetMapping("/{presetId}/washCheck")
+    public ApiResponse<PresetWashCheckResponse> washCheck(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long presetId
+    ) {
+        PresetWashCheckResponse data = presetService.washCheck(userId, presetId);
+        return ApiResponse.ok(null, data);
     }
 
     @GetMapping

--- a/src/main/java/gdg/hongik/project/gollazoom/presets/dto/response/PresetWashCheckResponse.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/presets/dto/response/PresetWashCheckResponse.java
@@ -1,0 +1,8 @@
+package gdg.hongik.project.gollazoom.presets.dto.response;
+
+import java.util.List;
+
+public record PresetWashCheckResponse(
+        boolean hasWashing, // 세탁중 옷이 1개라도 있으면 true
+        List<Long> washingClothIds
+) {}

--- a/src/main/java/gdg/hongik/project/gollazoom/presets/service/PresetService.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/presets/service/PresetService.java
@@ -1,13 +1,11 @@
 package gdg.hongik.project.gollazoom.presets.service;
 
 import gdg.hongik.project.gollazoom.closet.entity.Cloth;
+import gdg.hongik.project.gollazoom.closet.entity.WashStatus;
 import gdg.hongik.project.gollazoom.closet.repository.ClothRepository;
 import gdg.hongik.project.gollazoom.presets.dto.request.PresetCreateRequest;
 import gdg.hongik.project.gollazoom.presets.dto.request.PresetUpdateRequest;
-import gdg.hongik.project.gollazoom.presets.dto.response.PresetCreateResponse;
-import gdg.hongik.project.gollazoom.presets.dto.response.PresetDetailResponse;
-import gdg.hongik.project.gollazoom.presets.dto.response.PresetItemDetailResponse;
-import gdg.hongik.project.gollazoom.presets.dto.response.PresetListResponse;
+import gdg.hongik.project.gollazoom.presets.dto.response.*;
 import gdg.hongik.project.gollazoom.presets.entity.Preset;
 import gdg.hongik.project.gollazoom.presets.entity.PresetItem;
 import gdg.hongik.project.gollazoom.presets.entity.PresetSlot;
@@ -115,5 +113,19 @@ public class PresetService {
         Preset preset=presetRepository.findByIdAndUserId(presetId,userId)
                 .orElseThrow(()->new IllegalArgumentException("cannot find preset"));
         presetRepository.delete(preset);
+    }
+
+    public PresetWashCheckResponse washCheck(Long userId, Long presetId) {
+        Preset preset = presetRepository.findByIdAndUserId(presetId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("프리셋을 찾을 수 없습니다."));
+
+        List<Long> washingIds = preset.getItems().stream()
+                .map(PresetItem::getCloth)
+                .filter(c -> c.getWashStatus() == WashStatus.WASHING)
+                .map(Cloth::getId)
+                .toList();
+
+        // true일 경우, 세탁중인 옷의 id를 반환한다.
+        return new PresetWashCheckResponse(!washingIds.isEmpty(), washingIds);
     }
 }

--- a/src/main/java/gdg/hongik/project/gollazoom/user/controller/UserController.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/user/controller/UserController.java
@@ -1,17 +1,17 @@
 package gdg.hongik.project.gollazoom.user.controller;
 
-import gdg.hongik.project.gollazoom.user.dto.request.ChangePasswordRequest;
-import gdg.hongik.project.gollazoom.user.dto.request.LoginRequest;
-import gdg.hongik.project.gollazoom.user.dto.request.SignupRequest;
+import gdg.hongik.project.gollazoom.global.api.ApiResponse;
+import gdg.hongik.project.gollazoom.user.dto.request.*;
 
-import gdg.hongik.project.gollazoom.user.dto.request.WorktimeRequest;
 import gdg.hongik.project.gollazoom.user.dto.response.LoginResponse;
 import gdg.hongik.project.gollazoom.user.dto.response.MyInfoResponse;
+import gdg.hongik.project.gollazoom.user.dto.response.UserWashSettingResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import gdg.hongik.project.gollazoom.user.dto.response.UserResponse;
@@ -84,6 +84,22 @@ public class UserController {
                 .getAuthentication().getPrincipal();
 
         return ResponseEntity.ok(userService.getMyInfo(userId));
+    }
+
+    @GetMapping("/wash-setting")
+    public ApiResponse<UserWashSettingResponse> getWashSetting(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.ok( null, userService.getWashSetting(userId));
+    }
+
+    @PatchMapping("/wash-setting")
+    public ApiResponse<UserWashSettingResponse> updateWashSetting(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody UserWashSettingUpdateRequest request
+    ) {
+        return ApiResponse.ok("세탁 기능 설정이 변경되었어요.",
+                userService.updateWashSetting(userId, request));
     }
 
 }

--- a/src/main/java/gdg/hongik/project/gollazoom/user/dto/request/UserWashSettingUpdateRequest.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/user/dto/request/UserWashSettingUpdateRequest.java
@@ -1,0 +1,5 @@
+package gdg.hongik.project.gollazoom.user.dto.request;
+
+public record UserWashSettingUpdateRequest (
+        boolean isUsingWashUpTech
+) {}

--- a/src/main/java/gdg/hongik/project/gollazoom/user/dto/response/UserWashSettingResponse.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/user/dto/response/UserWashSettingResponse.java
@@ -1,0 +1,9 @@
+package gdg.hongik.project.gollazoom.user.dto.response;
+
+public record UserWashSettingResponse(
+        boolean isUsingWashUpTech
+) {
+    public static UserWashSettingResponse from(boolean v) {
+        return new UserWashSettingResponse(v);
+    }
+}

--- a/src/main/java/gdg/hongik/project/gollazoom/user/entity/User.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/user/entity/User.java
@@ -30,6 +30,9 @@ public class User {
     @Column
     private LocalTime worktime;
 
+    @Column(nullable = false)
+    private boolean isUsingWashUpTech = true; // 기본값으로 세탁 기능 사용을 true로 지정.
+
 
     @Builder
     private User(String username, String password, String nickname) {
@@ -37,4 +40,8 @@ public class User {
         this.password = password;
         this.nickname = nickname;
     }
+
+    public void changeIsUsingWashUpTech(boolean isUsingWashUpTech) {
+        this.isUsingWashUpTech = isUsingWashUpTech;
+    } // 세탁 기능 사용 변경
 }

--- a/src/main/java/gdg/hongik/project/gollazoom/user/service/UserService.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/user/service/UserService.java
@@ -3,8 +3,10 @@ package gdg.hongik.project.gollazoom.user.service;
 import gdg.hongik.project.gollazoom.security.JwtTokenProvider;
 import gdg.hongik.project.gollazoom.user.dto.request.ChangePasswordRequest;
 import gdg.hongik.project.gollazoom.user.dto.request.LoginRequest;
+import gdg.hongik.project.gollazoom.user.dto.request.UserWashSettingUpdateRequest;
 import gdg.hongik.project.gollazoom.user.dto.response.LoginResponse;
 import gdg.hongik.project.gollazoom.user.dto.response.MyInfoResponse;
+import gdg.hongik.project.gollazoom.user.dto.response.UserWashSettingResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -98,6 +100,19 @@ public class UserService {
                 user.getNickname(),
                 worktime
         );
+    }
+
+    @Transactional(readOnly = true)
+    public UserWashSettingResponse getWashSetting(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        return UserWashSettingResponse.from(user.isUsingWashUpTech());
+    }
+
+    @Transactional
+    public UserWashSettingResponse updateWashSetting(Long userId, UserWashSettingUpdateRequest request) {
+        User user = userRepository.findById(userId).orElseThrow();
+        user.changeIsUsingWashUpTech(request.isUsingWashUpTech());
+        return UserWashSettingResponse.from(user.isUsingWashUpTech());
     }
 }
 

--- a/src/main/java/gdg/hongik/project/gollazoom/wears/service/WearRecommendServiceImpl.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/wears/service/WearRecommendServiceImpl.java
@@ -3,6 +3,7 @@ package gdg.hongik.project.gollazoom.wears.service;
 import gdg.hongik.project.gollazoom.closet.entity.Category;
 import gdg.hongik.project.gollazoom.closet.entity.Cloth;
 import gdg.hongik.project.gollazoom.closet.entity.Season;
+import gdg.hongik.project.gollazoom.closet.entity.WashStatus;
 import gdg.hongik.project.gollazoom.closet.repository.ClothRepository;
 import gdg.hongik.project.gollazoom.presets.dto.response.PresetDetailResponse;
 import gdg.hongik.project.gollazoom.presets.dto.response.PresetItemDetailResponse;
@@ -90,11 +91,10 @@ public class WearRecommendServiceImpl implements  WearRecommendService{
 
         // 3. 내 옷 전체 로딩 후 카테고리 분류
         List<Cloth> allClothes = clothRepository.findAllByUser_IdOrderByCreatedAtDesc(user.getId());
-
-        List<Cloth> dresses = filterByCategory(allClothes, Category.DRESS);
-        List<Cloth> tops = filterByCategory(allClothes, Category.TOP);
-        List<Cloth> bottoms = filterByCategory(allClothes, Category.BOTTOM);
-        List<Cloth> outers = filterByCategory(allClothes, Category.OUTER);
+        // 정책 추가 : 세탁중이 아닌 옷만 우선적으로 추천 대상 옷에 포함시킨다.
+        List<Cloth> usableClothes = allClothes.stream()
+                .filter(c -> c.getWashStatus() != WashStatus.WASHING)
+                .toList();
 
         List<WearRecommendResponse.Recommendation> candidates = new ArrayList<>();
 
@@ -115,6 +115,7 @@ public class WearRecommendServiceImpl implements  WearRecommendService{
             if (!isValidCombination(presetClothes)) continue;
 
             // 3. 조건 위반 체크 (하나라도 위반될 시 프리셋은 더 이상 따지지 않는다.
+            if (presetClothes.stream().anyMatch(c -> c.getWashStatus() == WashStatus.WASHING)) continue;
             if (violatesRainRule(presetClothes, isRaining)) continue;
             if (violatesTemperatureRule(presetClothes, temperature)) continue;
             if (violatesYesterdayRule(presetClothes, yesterdayClothIds)) continue;
@@ -129,6 +130,12 @@ public class WearRecommendServiceImpl implements  WearRecommendService{
         }
 
         // 프리셋이 만족하지 않으면 continue로 인해 여기로 오게 됨.
+
+        List<Cloth> dresses = filterByCategory(usableClothes, Category.DRESS);
+        List<Cloth> tops = filterByCategory(usableClothes, Category.TOP);
+        List<Cloth> bottoms = filterByCategory(usableClothes, Category.BOTTOM);
+        final List<Cloth> primaryOuters = filterByCategory(usableClothes, Category.OUTER);
+        List<Cloth> fallbackOuters = primaryOuters;
 
         // 1. DRESS 단일 코디 후보
         for (Cloth d : dresses) {
@@ -148,20 +155,82 @@ public class WearRecommendServiceImpl implements  WearRecommendService{
                 if (base != null) candidates.add(base);
             }
         }
+        // 3. 후보 부족 시 세탁 중 옷 포함해서 다시 후보 추가 + 경고 메시지 반환
+        if (candidates.size() < 3) {
+            addFallbackCandidates(
+                    candidates,
+                    filterByCategory(allClothes, Category.DRESS),
+                    filterByCategory(allClothes, Category.TOP),
+                    filterByCategory(allClothes, Category.BOTTOM),
+                    isRaining, temperature, yesterdayClothIds
+            );
+            // 조합 폭발 막기위해 outer 따로 처리
+            fallbackOuters = filterByCategory(allClothes, Category.OUTER);
+        }
 
-        // 3. OUTER 추가 여부
+        // toList 불변 관련 컴파일 에러를 막기 위해 생성.
+        final List<Cloth> finalOuters = fallbackOuters;
+
+        // 4. OUTER 추가 여부
         List<WearRecommendResponse.Recommendation> withOuter = candidates.stream()
-                .map(base -> applyOuterPolicy(base, outers, isRaining, temperature, yesterdayClothIds))
+                .map(base -> applyOuterPolicy(base, finalOuters, isRaining, temperature, yesterdayClothIds))
                 .toList();
 
 
-        // 4. 정렬 및 상위 N개 반환
+        // 5. 정렬 및 상위 N개 반환
         List<WearRecommendResponse.Recommendation> top = withOuter.stream()
                 .sorted(Comparator.comparingInt(WearRecommendResponse.Recommendation::score).reversed())
                 .limit(3) // 일단 상위 3개만 반환, 사실 1개만 반환해도 됨. (강제성)
                 .toList();
 
         return new WearRecommendResponse(date, isRaining, temperature, top);
+    }
+
+    // fallback 후보 추가
+    private void addFallbackCandidates(
+            List<WearRecommendResponse.Recommendation> candidates,
+            List<Cloth> dresses,
+            List<Cloth> tops,
+            List<Cloth> bottoms,
+            boolean isRaining,
+            double temperature,
+            Set<Long> yesterdayClothIds
+    ) {
+        for (Cloth d : dresses) {
+            WearRecommendResponse.Recommendation r =
+                    scoreCandidate("DRESS", List.of(d), isRaining, temperature, yesterdayClothIds);
+            if (r != null) candidates.add(addWashFallbackWarningIfNeeded(r, List.of(d)));
+        }
+
+        List<Cloth> topPool = tops.stream().limit(10).toList();
+        List<Cloth> bottomPool = bottoms.stream().limit(10).toList();
+
+        for (Cloth t : topPool) {
+            for (Cloth b : bottomPool) {
+                List<Cloth> combo = List.of(t, b);
+                WearRecommendResponse.Recommendation r =
+                        scoreCandidate("TOP_BOTTOM", combo, isRaining, temperature, yesterdayClothIds);
+                if (r != null) candidates.add(addWashFallbackWarningIfNeeded(r, combo));
+            }
+        }
+    }
+
+    private WearRecommendResponse.Recommendation addWashFallbackWarningIfNeeded(
+            WearRecommendResponse.Recommendation base,
+            List<Cloth> clothes
+    ) {
+        boolean hasWashing = clothes.stream().anyMatch(c -> c.getWashStatus() == WashStatus.WASHING);
+        if (!hasWashing) return base;
+
+        List<String> warnings = new ArrayList<>(base.warnings());
+        warnings.add("추천 코디 후보가 부족하여 세탁중인 의상이 포함될 수 있어요.");
+
+        return new WearRecommendResponse.Recommendation(
+                base.type(),
+                base.score(),
+                warnings,
+                base.clothIds()
+        );
     }
 
     // 제외 디버깅용

--- a/src/main/java/gdg/hongik/project/gollazoom/wears/service/WearServiceImpl.java
+++ b/src/main/java/gdg/hongik/project/gollazoom/wears/service/WearServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -63,6 +64,10 @@ public class WearServiceImpl implements WearService{
         Wear wear = Wear.of(user, request.date());
         for (Cloth cloth : clothes) {
             wear.addItem(WearItem.of(cloth));
+        }
+
+        for (WearItem item : wear.getItems()) {
+            item.getCloth().updateLastWornAt(LocalDateTime.now());
         }
 
         Wear saved = wearRepository.save(wear);


### PR DESCRIPTION
## PR 제목

### PR을 한 이유 🎯

- 세탁 API 추가

### 이슈 번호 📎

- #21 

### 변경사항 🛠

1. 우선 Cloth에 세탁 상태 필드를  추다한다.
2. User에 값을 추가한다.
    1. isUsingWashUpTech를 만들고 프론트에서 처리
    2. users API GET으로 만들어서 프론트가 쓰기 편하게 하자.
3. 변경해야 할 API
    a. 모든 의상 조회에서 includeWashing 처리
    b. 세탁 상태 변경 : PATCH : washStatus
    c. 세탁 상태를 일괄로 변경 : 수동으로 체크를 쭉 해서 세탁 상태를 변경, PATCH washStatus clothIds : 쭉쭉
    d. 프리셋에 세탁중 포함 시 경고 팝업
        i. GET presets/{presetId}/washCheck
    e. 캘린더에서
        i. 캘린더에서 새로 등록 시 세탁중 옷은 기본으로 제외함.
        ii. 혹시 보여주되 경고하고 싶다면 리스트에서 빨간 테두리 + 세탁 중입니다 어쩌구
    f. 프리셋에서
        i. 프리셋 자체는 저장이 가능하다.
        ii. 착용 확정 단계에서 washCheck 결과가 True면 세탁중 의상 포함. 그래도 입을까요? yesorno
    g. 추천 코디에서
        i. 추천에서 세탁중인 옷은 원칙적으로 후보에서 제외
        ii. 단 옷이 부족하면 fallback : 세탁중인 옷이 포함될 수 있어요.
    h. 출근시간 + 10시간 이후에 세탁 팝업
        i. 앱 켜져있다면 프론트 타이머
        ii. 꺼져있다면 로컬 푸시 알림 or 서버 스케쥴러

### 특이사항 📌
h 관련 내용을 제외한 나머지는 구현 완료했으며, h 내용은 추후 완료하겠습니다.